### PR TITLE
Fix a person's name.

### DIFF
--- a/preface.textile
+++ b/preface.textile
@@ -212,7 +212,7 @@ I'd like to extend warmest thanks from my heart.
 | Kenichi Tamura |
 | Morikyu |
 | Yuya Kato |
-| Yasuhiro Kubo |
+| Takehiro Kubo |
 | Kentaro Goto |
 | Tomoyuki Shimomura |
 | Masaki Sukeda |


### PR DESCRIPTION
健洋 is Takehiro in English, not Yasuhiro.